### PR TITLE
Replace CDN invalidation path to wildcard

### DIFF
--- a/deploy-frontend/action.yml
+++ b/deploy-frontend/action.yml
@@ -29,5 +29,5 @@ runs:
       shell: bash
       run: >
         aws cloudfront create-invalidation
-        --paths "/+"
+        --paths "/*"
         --distribution-id "${{ inputs.aws-cloudfront-id }}"


### PR DESCRIPTION
invalidation seems to be not working quite as smoothly as I expected. This should fix it.